### PR TITLE
[choreonoid/README] fix 

### DIFF
--- a/Choreonoid/README.md
+++ b/Choreonoid/README.md
@@ -47,9 +47,9 @@ ROSのインストールとかはわかりきっとるものとしてスター�
 ```bash
 $ mkdir -p <catkin_ws>/src
 $ cd <catkin_ws>/src
-$ git clone -b devel git@github.com:WRS-TNK/choreonoid.git
-$ git clone -b devel git@github.com:WRS-TNK/choreonoid_ros_pkg.git
-$ git clone -b devel git@github.com:WRS-TNK/wrs_tnk_robot.git
+$ git clone -b develop https://github.com/WRS-TNK/choreonoid.git
+$ git clone -b develop https://github.com/WRS-TNK/choreonoid_ros_pkg.git
+$ git clone -b develop https://github.com/WRS-TNK/wrs_tnk_robot.git
 $ wstool init
 $ wstool set choreonoid_ros_pkg https://github.com/WRS-TNK/choreonoid_ros_pkg.git --git -y
 $ wstool update choreonoid_ros_pkg


### PR DESCRIPTION
- cloneするリポジトリのブランチ名を存在しない`devel` から実際に存在する`develop`へ修正
- リポジトリのリンクを誰でも使えるhttpsのものへ変更